### PR TITLE
Add support for the openat2 and faccessat2 syscalls in libseccomp.

### DIFF
--- a/include/seccomp-syscalls.h
+++ b/include/seccomp-syscalls.h
@@ -562,6 +562,8 @@
 
 #define __SNR_faccessat			__NR_faccessat
 
+#define __SNR_faccessat2		__NR_faccessat2
+
 #ifdef __NR_fadvise64
 #define __SNR_fadvise64			__NR_fadvise64
 #else

--- a/include/seccomp-syscalls.h
+++ b/include/seccomp-syscalls.h
@@ -1286,6 +1286,8 @@
 
 #define __SNR_openat			__NR_openat
 
+#define __SNR_openat2		__NR_openat2
+
 #ifdef __NR_pause
 #define __SNR_pause			__NR_pause
 #else

--- a/src/arch-aarch64-syscalls.c
+++ b/src/arch-aarch64-syscalls.c
@@ -92,6 +92,7 @@ const struct arch_syscall_def aarch64_syscall_table[] = { \
 	{ "exit", 93 },
 	{ "exit_group", 94 },
 	{ "faccessat", 48 },
+	{ "faccessat2", 439 },
 	{ "fadvise64", 223 },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", 47 },

--- a/src/arch-aarch64-syscalls.c
+++ b/src/arch-aarch64-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def aarch64_syscall_table[] = { \
 	{ "open_by_handle_at", 265 },
 	{ "open_tree", 428 },
 	{ "openat", 56 },
+	{ "openat2", 437 },
 	{ "pause", __PNR_pause },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-arm-syscalls.c
+++ b/src/arch-arm-syscalls.c
@@ -104,6 +104,7 @@ const struct arch_syscall_def arm_syscall_table[] = { \
 	{ "exit", (__SCMP_NR_BASE +  1) },
 	{ "exit_group", (__SCMP_NR_BASE + 248) },
 	{ "faccessat", (__SCMP_NR_BASE + 334) },
+	{ "faccessat2", (__SCMP_NR_BASE + 439) },
 	{ "fadvise64", __PNR_fadvise64 },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", (__SCMP_NR_BASE + 352) },

--- a/src/arch-arm-syscalls.c
+++ b/src/arch-arm-syscalls.c
@@ -278,6 +278,7 @@ const struct arch_syscall_def arm_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 371) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 322) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 29) },
 	{ "pciconfig_iobase", (__SCMP_NR_BASE + 271) },
 	{ "pciconfig_read", (__SCMP_NR_BASE + 272) },

--- a/src/arch-mips-syscalls.c
+++ b/src/arch-mips-syscalls.c
@@ -96,6 +96,7 @@ const struct arch_syscall_def mips_syscall_table[] = { \
 	{ "exit", (__SCMP_NR_BASE + 1) },
 	{ "exit_group", (__SCMP_NR_BASE + 246) },
 	{ "faccessat", (__SCMP_NR_BASE + 300) },
+	{ "faccessat2", (__SCMP_NR_BASE + 439) },
 	{ "fadvise64", __SCMP_NR_BASE + 254 },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", (__SCMP_NR_BASE + 320) },

--- a/src/arch-mips-syscalls.c
+++ b/src/arch-mips-syscalls.c
@@ -270,6 +270,7 @@ const struct arch_syscall_def mips_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 340) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 288) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 29) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-mips64-syscalls.c
+++ b/src/arch-mips64-syscalls.c
@@ -96,6 +96,7 @@ const struct arch_syscall_def mips64_syscall_table[] = { \
 	{ "exit", (__SCMP_NR_BASE + 58) },
 	{ "exit_group", (__SCMP_NR_BASE + 205) },
 	{ "faccessat", (__SCMP_NR_BASE + 259) },
+	{ "faccessat2", (__SCMP_NR_BASE + 439) },
 	{ "fadvise64", (__SCMP_NR_BASE + 215) },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", (__SCMP_NR_BASE + 279) },

--- a/src/arch-mips64-syscalls.c
+++ b/src/arch-mips64-syscalls.c
@@ -270,6 +270,7 @@ const struct arch_syscall_def mips64_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 299) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 247) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 33) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-mips64n32-syscalls.c
+++ b/src/arch-mips64n32-syscalls.c
@@ -96,6 +96,7 @@ const struct arch_syscall_def mips64n32_syscall_table[] = { \
 	{ "exit", (__SCMP_NR_BASE + 58) },
 	{ "exit_group", (__SCMP_NR_BASE + 205) },
 	{ "faccessat", (__SCMP_NR_BASE + 263) },
+	{ "faccessat2", (__SCMP_NR_BASE + 439) },
 	{ "fadvise64", (__SCMP_NR_BASE + 216) },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", (__SCMP_NR_BASE + 283) },

--- a/src/arch-mips64n32-syscalls.c
+++ b/src/arch-mips64n32-syscalls.c
@@ -270,6 +270,7 @@ const struct arch_syscall_def mips64n32_syscall_table[] = { \
 	{ "open_by_handle_at", (__SCMP_NR_BASE + 304) },
 	{ "open_tree", (__SCMP_NR_BASE + 428) },
 	{ "openat", (__SCMP_NR_BASE + 251) },
+	{ "openat2", (__SCMP_NR_BASE + 437) },
 	{ "pause", (__SCMP_NR_BASE + 33) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-parisc-syscalls.c
+++ b/src/arch-parisc-syscalls.c
@@ -76,6 +76,7 @@ const struct arch_syscall_def parisc_syscall_table[] = { \
 	{ "exit",	1 },
 	{ "exit_group",	222 },
 	{ "faccessat",	287 },
+	{ "faccessat2", 439 },
 	{ "fadvise64",	__PNR_fadvise64 },
 	{ "fadvise64_64",	236 },
 	{ "fallocate",	305 },

--- a/src/arch-parisc-syscalls.c
+++ b/src/arch-parisc-syscalls.c
@@ -250,6 +250,7 @@ const struct arch_syscall_def parisc_syscall_table[] = { \
 	{ "open_by_handle_at",	326 },
 	{ "open_tree", __PNR_open_tree },
 	{ "openat",	275 },
+	{ "openat2", 437 },
 	{ "pause",	29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-ppc-syscalls.c
+++ b/src/arch-ppc-syscalls.c
@@ -267,6 +267,7 @@ const struct arch_syscall_def ppc_syscall_table[] = { \
 	{ "open_by_handle_at", 346 },
 	{ "open_tree", 428 },
 	{ "openat", 286 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", 200 },
 	{ "pciconfig_read", 198 },

--- a/src/arch-ppc-syscalls.c
+++ b/src/arch-ppc-syscalls.c
@@ -93,6 +93,7 @@ const struct arch_syscall_def ppc_syscall_table[] = { \
 	{ "exit", 1 },
 	{ "exit_group", 234 },
 	{ "faccessat", 298 },
+	{ "faccessat2", 439 },
 	{ "fadvise64", 233 },
 	{ "fadvise64_64", 254 },
 	{ "fallocate", 309 },

--- a/src/arch-ppc64-syscalls.c
+++ b/src/arch-ppc64-syscalls.c
@@ -267,6 +267,7 @@ const struct arch_syscall_def ppc64_syscall_table[] = { \
 	{ "open_by_handle_at", 346 },
 	{ "open_tree", 428 },
 	{ "openat", 286 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", 200 },
 	{ "pciconfig_read", 198 },

--- a/src/arch-ppc64-syscalls.c
+++ b/src/arch-ppc64-syscalls.c
@@ -93,6 +93,7 @@ const struct arch_syscall_def ppc64_syscall_table[] = { \
 	{ "exit", 1 },
 	{ "exit_group", 234 },
 	{ "faccessat", 298 },
+	{ "faccessat2", 439 },
 	{ "fadvise64", 233 },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", 309 },

--- a/src/arch-s390-syscalls.c
+++ b/src/arch-s390-syscalls.c
@@ -76,6 +76,7 @@ const struct arch_syscall_def s390_syscall_table[] = { \
 	{ "exit", 1 },
 	{ "exit_group", 248 },
 	{ "faccessat", 300 },
+	{ "faccessat2", 439 },
 	{ "fadvise64", 253 },
 	{ "fadvise64_64", 264 },
 	{ "fallocate", 314 },

--- a/src/arch-s390-syscalls.c
+++ b/src/arch-s390-syscalls.c
@@ -250,6 +250,7 @@ const struct arch_syscall_def s390_syscall_table[] = { \
 	{ "open_by_handle_at", 336 },
 	{ "open_tree", 428 },
 	{ "openat", 288 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-s390x-syscalls.c
+++ b/src/arch-s390x-syscalls.c
@@ -250,6 +250,7 @@ const struct arch_syscall_def s390x_syscall_table[] = { \
 	{ "open_by_handle_at", 336 },
 	{ "open_tree", 428 },
 	{ "openat", 288 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-s390x-syscalls.c
+++ b/src/arch-s390x-syscalls.c
@@ -76,6 +76,7 @@ const struct arch_syscall_def s390x_syscall_table[] = { \
 	{ "exit", 1 },
 	{ "exit_group", 248 },
 	{ "faccessat", 300 },
+	{ "faccessat2", 439 },
 	{ "fadvise64", 253 },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", 314 },

--- a/src/arch-x32-syscalls.c
+++ b/src/arch-x32-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def x32_syscall_table[] = { \
 	{ "open_by_handle_at", (X32_SYSCALL_BIT + 304) },
 	{ "open_tree", (X32_SYSCALL_BIT + 428) },
 	{ "openat", (X32_SYSCALL_BIT + 257) },
+	{ "openat2", (X32_SYSCALL_BIT + 437) },
 	{ "pause", (X32_SYSCALL_BIT + 34) },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-x32-syscalls.c
+++ b/src/arch-x32-syscalls.c
@@ -92,6 +92,7 @@ const struct arch_syscall_def x32_syscall_table[] = { \
 	{ "exit", (X32_SYSCALL_BIT + 60) },
 	{ "exit_group", (X32_SYSCALL_BIT + 231) },
 	{ "faccessat", (X32_SYSCALL_BIT + 269) },
+	{ "faccessat2", (X32_SYSCALL_BIT + 439) },
 	{ "fadvise64", (X32_SYSCALL_BIT + 221) },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", (X32_SYSCALL_BIT + 285) },

--- a/src/arch-x86-syscalls.c
+++ b/src/arch-x86-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def x86_syscall_table[] = { \
 	{ "open_by_handle_at", 342 },
 	{ "open_tree", 428 },
 	{ "openat", 295 },
+	{ "openat2", 437 },
 	{ "pause", 29 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },

--- a/src/arch-x86-syscalls.c
+++ b/src/arch-x86-syscalls.c
@@ -92,6 +92,7 @@ const struct arch_syscall_def x86_syscall_table[] = { \
 	{ "exit", 1 },
 	{ "exit_group", 252 },
 	{ "faccessat", 307 },
+	{ "faccessat2", 439 },
 	{ "fadvise64", 250 },
 	{ "fadvise64_64", 272 },
 	{ "fallocate", 324 },

--- a/src/arch-x86_64-syscalls.c
+++ b/src/arch-x86_64-syscalls.c
@@ -266,6 +266,7 @@ const struct arch_syscall_def x86_64_syscall_table[] = { \
 	{ "open_by_handle_at", 304 },
 	{ "open_tree", 428 },
 	{ "openat", 257 },
+	{ "openat2", 437 },
 	{ "pause", 34 },
 	{ "pciconfig_iobase", __PNR_pciconfig_iobase },
 	{ "pciconfig_read", __PNR_pciconfig_read },
@@ -556,4 +557,3 @@ const struct arch_syscall_def *x86_64_syscall_iterate(unsigned int spot)
 	/* XXX - no safety checks here */
 	return &x86_64_syscall_table[spot];
 }
-

--- a/src/arch-x86_64-syscalls.c
+++ b/src/arch-x86_64-syscalls.c
@@ -92,6 +92,7 @@ const struct arch_syscall_def x86_64_syscall_table[] = { \
 	{ "exit", 60 },
 	{ "exit_group", 231 },
 	{ "faccessat", 269 },
+	{ "faccessat2", 439 },
 	{ "fadvise64", 221 },
 	{ "fadvise64_64", __PNR_fadvise64_64 },
 	{ "fallocate", 285 },


### PR DESCRIPTION
These will help with sysbox issue #273 as well as lay the ground work for adding support for running podman inside sysbox containers.