### PR TITLE
Add notices to Nestybox modified files for compliance with LGPL 2.1.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,12 @@ dnl # Seccomp Library
 dnl #
 
 dnl #
+dnl # NOTE:
+dnl # CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+dnl # MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+dnl #
+
+dnl #
 dnl # This library is free software; you can redistribute it and/or modify it
 dnl # under the terms of version 2.1 of the GNU Lesser General Public License
 dnl # as published by the Free Software Foundation.

--- a/include/seccomp-syscalls.h
+++ b/include/seccomp-syscalls.h
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/include/seccomp.h.in
+++ b/include/seccomp.h.in
@@ -7,6 +7,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/api.c
+++ b/src/api.c
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-aarch64-syscalls.c
+++ b/src/arch-aarch64-syscalls.c
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-arm-syscalls.c
+++ b/src/arch-arm-syscalls.c
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-mips-syscalls.c
+++ b/src/arch-mips-syscalls.c
@@ -7,6 +7,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-mips64-syscalls.c
+++ b/src/arch-mips64-syscalls.c
@@ -7,6 +7,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-mips64n32-syscalls.c
+++ b/src/arch-mips64n32-syscalls.c
@@ -7,6 +7,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-ppc-syscalls.c
+++ b/src/arch-ppc-syscalls.c
@@ -7,6 +7,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-ppc64-syscalls.c
+++ b/src/arch-ppc64-syscalls.c
@@ -7,6 +7,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-x86-syscalls.c
+++ b/src/arch-x86-syscalls.c
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/arch-x86_64-syscalls.c
+++ b/src/arch-x86_64-syscalls.c
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/system.c
+++ b/src/system.c
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.

--- a/src/system.h
+++ b/src/system.h
@@ -6,6 +6,12 @@
  */
 
 /*
+ * NOTE:
+ * CHANGES MADE BY NESTYBOX, INC. ON 12/2019 TO ADD SUPPORT FOR SECCOMP-NOTIFY.
+ * MOST OF THESE CHANGES HAVE BEEN SINCE UPSTREAMED TO THE OFFICIAL LIBSECCOMP.
+ */
+
+/*
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of version 2.1 of the GNU Lesser General Public License as
  * published by the Free Software Foundation.


### PR DESCRIPTION
Per the LGPL 2.1 license, the nestybox/libseccomp qualifies as a "work based on
the [original libseccomp] library", and therefore any files changed by Nestybox
"must cause the files modified to carry prominent notices stating that you
changed the files and the date of any change."

This commit adds such notices.

Signed-off-by: Cesar Talledo <ctalledo@nestybox.com>